### PR TITLE
Improved usability and ergonomics of the finders API

### DIFF
--- a/cubiomes/src/finders.rs
+++ b/cubiomes/src/finders.rs
@@ -5,7 +5,6 @@ pub use libcubiomes_sys::BiomeID;
 pub use libcubiomes_sys::Dimension;
 pub use libcubiomes_sys::MCVersion;
 
-
 pub struct CubiomesFinder {
     generator: MaybeUninit<libcubiomes_sys::Generator>,
 }
@@ -17,18 +16,14 @@ impl CubiomesFinder {
                 generator: MaybeUninit::zeroed(),
             };
             libcubiomes_sys::setupGenerator(finder.generator.as_mut_ptr(), version as c_int, 0);
-            libcubiomes_sys::applySeed(
-                finder.generator.as_mut_ptr(),
-                dim,
-                seed as u64,
-            );
+            libcubiomes_sys::applySeed(finder.generator.as_mut_ptr(), dim, seed as u64);
             finder
         }
     }
 
     pub fn apply_seed(&mut self, seed: i64, dim: Dimension) {
         unsafe {
-            libcubiomes_sys::applySeed(self.generator.as_mut_ptr(), dim, seed as u64);   
+            libcubiomes_sys::applySeed(self.generator.as_mut_ptr(), dim, seed as u64);
         }
     }
 
@@ -82,53 +77,52 @@ pub struct BiomeCache {
 }
 
 impl BiomeCache {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         finder: &CubiomesFinder,
         scale: CoordScaling,
-        x: i32,
-        z: i32,
-        sx: i32,
-        sz: i32,
-        y: i32,
-        sy: i32,
+        range_start: (i32, i32, i32), // (x, y, z)
+        range_size: (i32, i32, i32),  // (sx, sy, sz)
     ) -> Self {
         unsafe {
             let r = libcubiomes_sys::Range {
                 scale: scale.value(), // Divide your input coordinates by this value
                 // Define the position and size for a horizontal area:
-                x,
-                z,  // position (x,z)
-                sx, // size (width,height)
-                sz,
-                // Set the vertical range as a plane near sea level at scale 1:4 (unless 1:1).
-                y,
-                sy,
+                x: range_start.0, // position (x, y, z)
+                y: range_start.1,
+                z: range_start.2,
+                sx: range_size.0, // size (width, vertical range, height)
+                sy: range_size.1, // Set the vertical range as a plane near sea level at scale 1:4 (unless Coordscaling == Block [1:1]).
+                sz: range_size.2,
             };
             let biome_id_cache: *mut BiomeID =
                 libcubiomes_sys::allocCache(finder.generator.as_ptr(), r);
             libcubiomes_sys::genBiomes(finder.generator.as_ptr(), biome_id_cache, r);
             BiomeCache {
                 biome_id_cache,
-                x,
-                y,
-                z,
-                sx,
-                sy,
-                sz,
+                x: range_start.0,
+                y: range_start.1,
+                z: range_start.2,
+                sx: range_size.0,
+                sy: range_size.1,
+                sz: range_size.2,
             }
         }
     }
 
     pub fn is_in_bounds(&self, x: i32, y: i32, z: i32) -> bool {
-        x >= self.x && x < self.x + self.sx && y >= self.y && y < self.y + self.sy && z >= self.z && z < self.z + self.sz
+        x >= self.x
+            && x < self.x + self.sx
+            && y >= self.y
+            && y < self.y + self.sy
+            && z >= self.z
+            && z < self.z + self.sz
     }
 
     pub fn get_biome_at(&self, x: i32, y: i32, z: i32) -> BiomeID {
         if !self.is_in_bounds(x, y, z) {
             panic!(
-                "Coordinate out of range for cache! Accepted: (x:{}..{}, z:{}..{}), Received: (x:{}, z:{}).",
-                    self.x, self.x + self.sx, self.z, self.z + self.sz, x, z
+                "Coordinate out of range for cache! Accepted: (x:{}..{}, y:{}..{}, z:{}..{}), Received: (x:{}, y:{}, z:{}).",
+                    self.x, self.x + self.sx, self.y, self.y + self.sy, self.z, self.z + self.sz, x, y, z
             );
         }
         let i_x = x - self.x;

--- a/cubiomes/src/finders.rs
+++ b/cubiomes/src/finders.rs
@@ -1,23 +1,21 @@
-use std::ffi::{c_int, c_void};
 use std::mem::MaybeUninit;
+use std::ffi::{c_int, c_void};
 
 pub use libcubiomes_sys::BiomeID;
+pub use libcubiomes_sys::MCVersion;
+
 
 pub struct CubiomesFinder {
     generator: MaybeUninit<libcubiomes_sys::Generator>,
 }
 
 impl CubiomesFinder {
-    pub fn new(seed: i64) -> Self {
+    pub fn new(seed: i64, version: MCVersion) -> Self {
         unsafe {
             let mut finder = CubiomesFinder {
                 generator: MaybeUninit::zeroed(),
             };
-            libcubiomes_sys::setupGenerator(
-                finder.generator.as_mut_ptr(),
-                libcubiomes_sys::MCVersion_MC_1_19 as c_int,
-                0,
-            );
+            libcubiomes_sys::setupGenerator(finder.generator.as_mut_ptr(), version as c_int, 0);
             libcubiomes_sys::applySeed(
                 finder.generator.as_mut_ptr(),
                 libcubiomes_sys::Dimension_DIM_OVERWORLD,
@@ -40,6 +38,31 @@ impl CubiomesFinder {
     }
 }
 
+pub enum CoordScaling {
+    /// 1:1 block scaling
+    Block,
+    /// 1:4 scaling
+    Quad,
+    /// 1:16 chunk scaling
+    Chunk,
+    /// 1:64 scaling
+    QuadChunk,
+    /// 1:256 scaling (**Overworld only**)
+    Region,
+}
+
+impl CoordScaling {
+    pub fn value(&self) -> i32 {
+        match self {
+            CoordScaling::Block => 1,
+            CoordScaling::Quad => 4,
+            CoordScaling::Chunk => 16,
+            CoordScaling::QuadChunk => 64,
+            CoordScaling::Region => 256,
+        }
+    }
+}
+
 /// https://github.com/Cubitect/cubiomes/tree/master#biome-generation-in-a-range
 pub struct BiomeCache {
     x: i32,
@@ -52,12 +75,19 @@ pub struct BiomeCache {
 }
 
 impl BiomeCache {
-    pub fn new(finder: &CubiomesFinder, x: i32, z: i32, sx: i32, sz: i32) -> Self {
+    pub fn new(
+        finder: &CubiomesFinder,
+        scale: CoordScaling,
+        x: i32,
+        z: i32,
+        sx: i32,
+        sz: i32,
+    ) -> Self {
         unsafe {
             let y = 63;
             let sy = 1;
             let r = libcubiomes_sys::Range {
-                scale: 16, // 1:16, a.k.a. horizontal chunk scaling
+                scale: scale.value(), // Divide your input coordinates by this value
                 // Define the position and size for a horizontal area:
                 x,
                 z,  // position (x,z)
@@ -81,14 +111,17 @@ impl BiomeCache {
             }
         }
     }
+
     pub fn is_in_bounds(&self, x: i32, z: i32) -> bool {
-        //!(x >= self.x + self.sx || x < self.x || z >= self.z + self.sz || z < self.z)
         x >= self.x && x < self.x + self.sx && z >= self.z && z < self.z + self.sz
     }
 
     pub fn get_biome_at(&self, x: i32, z: i32) -> BiomeID {
         if !self.is_in_bounds(x, z) {
-            panic!("Coordinate out of range for cache!");
+            panic!(
+                "Coordinate out of range for cache! Accepted: (x:{}..{}, z:{}..{}), Received: (x:{}, z:{}).",
+                    self.x, self.x + self.sx, self.z, self.z + self.sz, x, z
+            );
         }
         let i_x = x - self.x;
         let i_y = 0;

--- a/libcubiomes-sys/build/build.rs
+++ b/libcubiomes-sys/build/build.rs
@@ -44,11 +44,10 @@ fn generate_bindings() -> Result<()> {
 
 fn build_with_make() -> Result<MakeResult> {
     // Copy to OUT_DIR as objects and lib are generated within the same directory
-    let ref cubiomes_build_dir = PathBuf::from(env::var("OUT_DIR")?).join("cubiomes_build");
+    let cubiomes_build_dir = &PathBuf::from(env::var("OUT_DIR")?).join("cubiomes_build");
     if !cubiomes_build_dir.exists() {
         println!("Copying folder vendor to {cubiomes_build_dir:?} for building");
-        let mut options = fs_extra::dir::CopyOptions::default();
-        options.copy_inside = true;
+        let options = fs_extra::dir::CopyOptions { copy_inside: true, ..Default::default() };
         fs_extra::dir::copy("vendor", cubiomes_build_dir, &options)?;
         println!("Copied folder vendor to {cubiomes_build_dir:?} for building");
     }
@@ -59,7 +58,7 @@ fn build_with_make() -> Result<MakeResult> {
         "release"
     };
     let make_exit_code = match Command::new("make")
-        .args(&["-C", cubiomes_build_dir.to_str().unwrap(), profile])
+        .args(["-C", cubiomes_build_dir.to_str().unwrap(), profile])
         .status()
     {
         Ok(exit_code) => exit_code,


### PR DESCRIPTION
These changes improve the usability and ergonomics of the finders API. 

## CubiomesFinder

Previously, the **CubiomesFinder** was hardcoded to Minecraft version 1.19, and the overworld dimension.

I refactored the API so that you can specify any game version and dimension that you would like to work with.

I have also implemented the `apply_seed()` method on **CubiomesFinder**, to facilitate seed finders without the need for spam-creating new CubiomesFinder instances.

## BiomeCache

I've modified the **BiomeCache** to respect values given for `y` and `sy`, instead of having them hardcoded.
This should allow for writing scanners which concern themselves with scanning cave biomes on game versions >= 1.18.

EDIT: The `new()` method has also been changed to accept tuples for the `x, y, z` and `sx, sy, sz` values. This keeps the number of needed parameters in the signature to a minimum, while still allowing for maximum customizability.

Additionally, I've implemented an abstraction for coordinate scaling in the form of the **CoordScaling** enum.
The variants correspond to the possible values for `scale`: **Block = 1, Quad = 4, Chunk = 16, QuadChunk = 64, Region = 256**.
In my mind, this clarifies the purpose and usage of the `scale` parameter, which can be slightly confusing for newcomers to Cubiomes.

Next, I've updated the `is_in_bounds()` method to reflect the variability of the `y` parameter by checking for its bounds as well.

I've also improved the panic message that occurs when out-of-bounds coordinates are provided to the API.
It now shows you exactly why your coordinates were out of bounds (and what it was expecting).

Lastly, I updated the `get_biome_at()` method to work with variable values for `y`, instead of having it hardcoded at 0.

## Misc

I also fixed the linter warnings in the libcubiomes-sys crate's build.rs file, because I'm ocd like that.